### PR TITLE
Upkona codex/plan for translating python library to rust

### DIFF
--- a/PORTING_TASKS.md
+++ b/PORTING_TASKS.md
@@ -1,0 +1,39 @@
+# Python to Rust Porting Tasks
+
+This document breaks down the porting process into epochs. Each epoch corresponds to a single Python file that will be translated into Rust. The order roughly follows the cycle-based plan (configuration & utilities, layers, models, engine, API).
+
+## Cycle 1: Configuration and Utilities
+1. `nanovllm/config.py` – implement Config struct and validation logic in Rust.
+2. `nanovllm/utils/context.py` – implement context management utilities.
+3. `nanovllm/utils/loader.py` – implement model weight loading helpers.
+4. `nanovllm/utils/memory.py` – implement GPU memory query helper.
+
+## Cycle 2: Layers
+5. `nanovllm/layers/activation.py` – port SiluAndMul activation layer.
+6. `nanovllm/layers/attention.py` – port Attention module and kernel helpers.
+7. `nanovllm/layers/embed_head.py` – port embedding and LM head layers.
+8. `nanovllm/layers/layernorm.py` – port RMSNorm implementation.
+9. `nanovllm/layers/linear.py` – port linear layers (replicated/parallel).
+10. `nanovllm/layers/rotary_embedding.py` – port rotary embedding utilities.
+11. `nanovllm/layers/sampler.py` – port sampling layer.
+
+## Cycle 3: Model Definition
+12. `nanovllm/models/qwen3.py` – port Qwen3 model and related classes.
+
+## Cycle 4: Engine Core
+13. `nanovllm/engine/sequence.py` – port Sequence data structure.
+14. `nanovllm/engine/block_manager.py` – port block management logic.
+15. `nanovllm/engine/scheduler.py` – port Scheduler.
+16. `nanovllm/engine/model_runner.py` – port ModelRunner including CUDA-graph logic (adapted for CPU).
+17. `nanovllm/engine/llm_engine.py` – port LLMEngine orchestration.
+
+## Cycle 5: Public API
+18. `nanovllm/sampling_params.py` – port SamplingParams dataclass.
+19. `nanovllm/llm.py` – port top-level LLM class.
+20. `nanovllm/__init__.py` – re-export Rust bindings to maintain API.
+
+## Cycle 6: Examples and Benchmarks (optional)
+21. `example.py` – reimplement example using Rust library.
+22. `bench.py` – port benchmark script if desired.
+
+Each task should follow the workflow described in the main porting plan: create stubs, implement functionality, test against the Python version via PyO3 bindings, and commit once the epoch passes all checks.

--- a/PORTING_TASKS.md
+++ b/PORTING_TASKS.md
@@ -37,3 +37,17 @@ This document breaks down the porting process into epochs. Each epoch correspond
 22. `bench.py` – port benchmark script if desired.
 
 Each task should follow the workflow described in the main porting plan: create stubs, implement functionality, test against the Python version via PyO3 bindings, and commit once the epoch passes all checks.
+
+## Framework Setup Tasks
+1. Create a Rust crate `rust-core` mirroring the `nanovllm` package structure.
+2. Create a separate crate `bindings` using PyO3 and maturin to expose the Rust API to Python.
+3. Configure a Cargo workspace tying both crates together and update `pyproject.toml` to use maturin as the build backend.
+4. Stub each module in `rust-core` before translation so the crate compiles.
+5. Implement unit tests in Rust and reuse Python tests via the PyO3 bridge.
+6. Set up `cargo-nextest` and `criterion` for testing and benchmarking.
+7. Add GitHub Actions workflows to build the Rust project, run nextest, and execute Python tests through maturin.
+
+## Dependency Mapping Tasks
+1. For each Python import, document the corresponding Rust crate (e.g., `numpy` -> `ndarray`, `torch` -> `tch-rs`).
+2. Write small comparison tests to ensure the Rust crate produces identical results to the Python module for key operations.
+3. Note any API differences and how they will be handled in the Rust implementation.


### PR DESCRIPTION
This pull request adds a comprehensive porting plan for translating the `nanovllm` Python package into Rust. The plan is organized into cycles based on functionality, detailing tasks for each module to be ported, along with setup and dependency mapping instructions.

### Porting Plan Overview:
* **Epoch-based Porting Tasks**: Introduced a cycle-based breakdown of porting tasks, covering configuration, utilities, layers, models, engine core, public API, and optional examples/benchmarks.

### Framework Setup:
* **Rust Crate Setup**: Defined tasks for creating a `rust-core` crate mirroring the Python package, a `bindings` crate for PyO3 integration, and a Cargo workspace to tie them together.
* **Testing and Benchmarking**: Outlined steps for implementing unit tests in Rust, reusing Python tests via PyO3, and setting up `cargo-nextest` and `criterion` for testing and benchmarking.
* **CI/CD Integration**: Added tasks for configuring GitHub Actions workflows to build the Rust project, run tests, and execute Python tests through maturin.

### Dependency Mapping:
* **Python to Rust Dependencies**: Documented mappings between Python imports and corresponding Rust crates, along with instructions for comparison testing and handling API differences. (Fec285e7R