### PR TITLE
Add documentation for Rust rewrite

### DIFF
--- a/.github/ISSUE_TEMPLATE/porting_task.md
+++ b/.github/ISSUE_TEMPLATE/porting_task.md
@@ -1,0 +1,19 @@
+<!-- Template for porting a Python module to Rust -->
+
+**Cycle & Epoch**: <!-- e.g. Cycle 1 / Epoch 2 -->
+
+**Target Module**:
+- Original: `<path/to/python.py>`
+- Destination: `<path/to/rust.rs>`
+
+**Description**
+Briefly describe the purpose of the original code and the plan for the Rust version. Mention important data structures or tricky parts.
+
+**Acceptance Criteria**
+- [ ] All major functions/classes are implemented in Rust
+- [ ] Tests added and passing
+- [ ] PyO3 bindings updated if needed
+- [ ] Documentation updated (ARCHITECTURE.md, DESIGN_DECISIONS.md, etc.)
+
+**Dependencies**
+List any epochs that must be completed first.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description of Changes
+Describe which epoch is implemented and summarize major changes.
+
+## Implementation Details
+Explain any notable design decisions or deviations from the original Python code.
+
+## Testing Done
+- [ ] `cargo test`
+- [ ] Additional tests / parity checks
+
+## Checklist
+- [ ] Issue linked
+- [ ] Code formatted with `cargo fmt` and linted with `cargo clippy`
+- [ ] Documentation updated
+- [ ] Benchmarks updated if applicable

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,14 @@
+# Architecture
+
+Tiny-vLLM mirrors the original vLLM layout. Each Python module has a corresponding Rust module so behavior can be compared directly. The table below highlights the mapping.
+
+| Python Source | Rust Module | Notes |
+|---------------|------------|-------|
+| `nanovllm/config.py` | `src/config.rs` | Engine configuration struct using Serde |
+| `nanovllm/engine/llm_engine.py` | `src/engine.rs` | Core engine for token generation |
+| `nanovllm/engine/async_llm_engine.py` | `src/engine_async.rs` | Asynchronous wrapper for concurrency |
+| `nanovllm/engine/scheduler.py` | `src/scheduler.rs` | Request scheduler for continuous batching |
+| `nanovllm/engine/model_runner.py` | `src/model_runner.rs` | Loads models via `tch` and runs forward passes |
+| `nanovllm/layers/...` | `src/layers/...` | Individual neural net layers |
+
+Components communicate through a shared `VllmConfig`. PyO3 exposes a Python-facing `LLM` class that instantiates the Rust engine under the hood. The design keeps Rust logic self contained so it can be used as a native crate or via Python bindings.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,13 @@
+# Benchmarks
+
+Benchmarking ensures the Rust engine matches or surpasses the Python version. We use [Criterion.rs](https://github.com/bheisler/criterion.rs) for micro benchmarks and compare against the original `bench.py` script.
+
+## Baseline
+Early tests on the Python implementation (RTX 4070, Qwen3-0.6B) show around 1314 tokens/s throughput for 256 requests. This serves as our reference.
+
+## Methodology
+- Run `cargo bench` for Rust micro benchmarks.
+- Use the same model weights and sampling parameters when comparing against Python vLLM.
+- Measure aggregate tokens/second and per-request latency for varying numbers of concurrent prompts.
+
+Results will be added here as the port progresses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thank you for helping with the Rust rewrite of Tiny-vLLM! Development follows an epoch based workflow where each Python file is ported in its own pull request.
+
+## Development Setup
+1. Install the latest stable Rust toolchain.
+2. Build the project with `cargo build` (set `LIBTORCH_USE_PYTORCH=1` if PyTorch is installed).
+3. Run tests with `cargo test`. There are currently no automated Python tests, but parity checks are encouraged.
+4. Format with `cargo fmt` and lint using `cargo clippy` before submitting a PR.
+
+## Workflow
+- Create an issue using `.github/ISSUE_TEMPLATE/porting_task.md` for the file you wish to port.
+- Work in a feature branch named after the epoch (e.g. `epoch-2-engine`).
+- Keep commits focused. One module per PR is preferred.
+- When opening a PR, use `.github/PULL_REQUEST_TEMPLATE.md` and link the issue.
+
+## Commit Messages
+Include the epoch number and module name in the title, e.g. `Epoch 3: port model_runner`. Describe major decisions in the body.
+
+## Testing
+Run `cargo test` before pushing. If you add Python parity tests, run `pytest` as well.
+
+## Documentation
+Update `ARCHITECTURE.md` and `docs/porting_plan.md` when new modules are completed. Benchmarks should be recorded in `BENCHMARKS.md`.

--- a/DESIGN_DECISIONS.md
+++ b/DESIGN_DECISIONS.md
@@ -1,0 +1,15 @@
+# Design Decisions
+
+This document captures the rationale for key choices in the Rust port.
+
+## tch-rs for Tensor Operations
+We rely on the `tch` crate which binds to PyTorch's `libtorch`. This lets us reuse the same GPU kernels as vLLM and load existing PyTorch checkpoints without conversion. Alternatives like burn or candle were considered but lack some optimized ops we need today.
+
+## PyO3 for Python Interop
+Tiny-vLLM intends to be a drop-in replacement for the Python API. Using PyO3 allows the Rust engine to be imported as a Python module. It also enables parity tests against the original implementation.
+
+## One File, One Epoch
+Porting is organized so that each epoch corresponds to a single Python file. This keeps pull requests focused and aids verification. Stub modules may be committed first so later epochs can compile against them.
+
+## Static Compilation
+The Rust crates build as `cdylib` for Python but also support static binaries. We set `LIBTORCH_USE_PYTORCH=1` when building so `tch` links against the same libtorch as Python's `torch` package, avoiding version mismatches.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,46 @@
-# Nano-vLLM
+# Tiny-vLLM
 
-A lightweight vLLM implementation built from scratch.
+Tiny-vLLM is a ground-up rewrite (port) of the vLLM inference engine from Python to Rust. The repository currently contains a lightweight Python implementation (`nanovllm`) used as a reference. As development progresses, the Rust crate will mirror the original architecture while exposing a similar API via PyO3.
 
 ## Key Features
 
 * 🚀 **Fast offline inference** - Comparable inference speeds to vLLM
-* 📖 **Readable codebase** - Clean implementation in ~ 1,200 lines of Python code
+* 📖 **Readable codebase** - Clean implementation in ~1,200 lines of Python code and a growing Rust port
 * ⚡ **Optimization Suite** - Prefix caching, Tensor Parallelism, Torch compilation, CUDA graph, etc.
 
-## Installation
+## Quick Start (Rust)
+
+Ensure a recent Rust toolchain is installed. Build the library and run tests with:
 
 ```bash
-pip install git+https://github.com/GeeeekExplorer/nano-vllm.git
+cargo build --release
+cargo test
 ```
 
-## Quick Start
+The Python example (`example.py`) still works with the reference implementation. As Rust code lands, bindings will be exposed so usage remains largely the same:
 
-See `example.py` for usage. The API mirrors vLLM's interface with minor differences in the `LLM.generate` method.
 ```python
 from nanovllm import LLM, SamplingParams
 llm = LLM("/YOUR/MODEL/PATH", enforce_eager=True, tensor_parallel_size=1)
 sampling_params = SamplingParams(temperature=0.6, max_tokens=256)
-prompts = ["Hello, Nano-vLLM."]
-outputs = llm.generate(prompts, sampling_params)
-outputs[0]["text"]
+outputs = llm.generate(["Hello, Nano-vLLM."], sampling_params)
+print(outputs[0]["text"])
 ```
+
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) explains the module layout and Python ↔ Rust mapping.
+- [ROADMAP.md](ROADMAP.md) outlines the planned cycles and milestones.
+- [CONTRIBUTING.md](CONTRIBUTING.md) describes the workflow for porting epochs.
+- [docs/porting_plan.md](docs/porting_plan.md) tracks the detailed file-by-file plan.
 
 ## Benchmark
 
-See `bench.py` for benchmark.
+See `bench.py` for the original benchmark setup. Preliminary results on a RTX 4070 running the Python engine show:
 
-**Test Configuration:**
-- Hardware: RTX 4070
-- Model: Qwen3-0.6B
-- Total Requests: 256 sequences
-- Input Length: Randomly sampled between 100–1024 tokens
-- Output Length: Randomly sampled between 100–1024 tokens
-
-**Performance Results:**
 | Inference Engine | Output Tokens | Time (s) | Throughput (tokens/s) |
 |----------------|-------------|----------|-----------------------|
 | vLLM           | 133,966     | 98.95    | 1353.86               |
 | Nano-vLLM      | 133,966     | 101.90   | 1314.65               |
+
+We will add Rust benchmark numbers in [BENCHMARKS.md](BENCHMARKS.md) as the port progresses.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,32 @@
+# Roadmap
+
+This roadmap summarizes the development schedule for the Rust rewrite. Cycles group related epochs and culminate in a milestone where Tiny-vLLM reaches a usable state.
+
+## Cycle 0 – Setup *(completed)*
+- Repository scaffolding
+- PyO3 bridge verification
+
+## Cycle 1 – Core Engine MVP
+Goal: basic offline generation for a single prompt.
+- Epoch 1: configuration module
+- Epoch 2: synchronous engine
+- Epoch 3: model loader
+- Epoch 4: sampling utilities
+- Epoch 5: end-to-end parity test
+
+## Cycle 2 – Parallelism
+Goal: handle multiple requests with batching.
+- Epoch 6: async engine
+- Epoch 7: scheduler
+- Epoch 8: attention cache
+- Epoch 9: streaming outputs
+- Epoch 10: throughput and load testing
+
+## Cycle 3 – Feature Parity
+Goal: match vLLM features and tune performance.
+- Epoch 11: HTTP server
+- Epoch 12: advanced model support
+- Epoch 13: extensive tests
+- Epoch 14: performance tuning
+
+Future cycles may include pure Rust tokenizers, fine tuning support, and broader ecosystem integration. Refer to `docs/porting_plan.md` for detailed tasks.

--- a/docs/porting_plan.md
+++ b/docs/porting_plan.md
@@ -1,0 +1,34 @@
+Tiny-vLLM Porting Plan
+======================
+
+This plan breaks down the project into cycles and epochs. Each epoch corresponds to porting a single Python file or feature to Rust. The approach follows "one file, one epoch" so progress is incremental and easy to review.
+
+Cycle 0: Project Setup and Infrastructure
+----------------------------------------
+- Epoch 0.1: Repository scaffolding and initial Rust crates.
+- Epoch 0.2: PyO3 bridge bootstrap to verify building as a Python module.
+
+Cycle 1: Core Engine MVP (Offline Inference)
+-------------------------------------------
+- Epoch 1: Port `vllm_config.py` to `src/config.rs`.
+- Epoch 2: Port `llm_engine.py` to `src/engine.rs`.
+- Epoch 3: Port model loading code (`model_runner.py` and helpers).
+- Epoch 4: Port `sampling_params.py` and sampling utilities.
+- Epoch 5: Integrate pieces and run an end-to-end parity test against Python.
+
+Cycle 2: Parallelism and Serving Features
+----------------------------------------
+- Epoch 6: Port `async_llm_engine.py` to Rust.
+- Epoch 7: Port `scheduler.py` for request batching.
+- Epoch 8: Implement attention cache management (paged attention).
+- Epoch 9: Add streaming support for partial outputs.
+- Epoch 10: Parity and load testing with multiple requests.
+
+Cycle 3: Feature Parity and Optimization
+---------------------------------------
+- Epoch 11: Port the OpenAI-compatible HTTP server.
+- Epoch 12: Support distributed or quantized models as available.
+- Epoch 13: Comprehensive testing and edge cases.
+- Epoch 14: Performance tuning and final optimizations.
+
+Each epoch has an associated GitHub issue using the template in `.github/ISSUE_TEMPLATE/porting_task.md`. See `ROADMAP.md` for high level milestones. As epochs finish, update this file to mark progress and note any design deviations.


### PR DESCRIPTION
## Summary
- add README section on Rust port
- document architecture, design choices, roadmap and benchmarks
- create contributing guide and porting plan
- add GitHub issue and PR templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c1e3cd9c83319333e285f406c01b