### PR TITLE
Add helpers utilities to Rust core

### DIFF
--- a/nanovllm/utils/helpers.py
+++ b/nanovllm/utils/helpers.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+def clamp(value: int, min_value: int, max_value: int) -> int:
+    """Clamp ``value`` to the inclusive range [min_value, max_value]."""
+    return max(min(value, max_value), min_value)
+
+
+def flatten(list_of_lists: list[list[int]]) -> list[int]:
+    """Flatten a list of lists into a single list."""
+    return [item for sublist in list_of_lists for item in sublist]
+
+
+def chunked(lst: list[int], size: int) -> list[list[int]]:
+    """Split a list into chunks of the given size."""
+    if size <= 0:
+        return []
+    return [lst[i : i + size] for i in range(0, len(lst), size)]
+

--- a/tests/python/test_helpers.py
+++ b/tests/python/test_helpers.py
@@ -1,0 +1,25 @@
+import importlib.util
+import pathlib
+import tiny_vllm_py
+
+helpers_path = pathlib.Path('nanovllm/utils/helpers.py')
+spec = importlib.util.spec_from_file_location('py_helpers', helpers_path)
+py_helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(py_helpers)
+
+
+def test_clamp():
+    for v in [-5, 0, 5, 10, 15]:
+        assert tiny_vllm_py.clamp(v, 0, 10) == py_helpers.clamp(v, 0, 10)
+
+
+def test_flatten():
+    data = [[1, 2], [3, 4, 5], []]
+    assert tiny_vllm_py.flatten(data) == py_helpers.flatten(data)
+
+
+def test_chunked():
+    data = list(range(7))
+    assert tiny_vllm_py.chunked(data, 3) == py_helpers.chunked(data, 3)
+    assert tiny_vllm_py.chunked(data, 0) == py_helpers.chunked(data, 0)
+

--- a/tiny-vllm-core/src/helpers.rs
+++ b/tiny-vllm-core/src/helpers.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+
+/// Clamp `value` to the inclusive range [min_value, max_value].
+pub fn clamp(value: i64, min_value: i64, max_value: i64) -> i64 {
+    if value < min_value {
+        min_value
+    } else if value > max_value {
+        max_value
+    } else {
+        value
+    }
+}
+
+/// Flatten a vector of vectors into a single vector.
+pub fn flatten(list_of_lists: Vec<Vec<i64>>) -> Vec<i64> {
+    list_of_lists.into_iter().flatten().collect()
+}
+
+/// Split a vector into chunks of a given size.
+pub fn chunked(lst: Vec<i64>, size: usize) -> Vec<Vec<i64>> {
+    if size == 0 {
+        return Vec::new();
+    }
+    lst.chunks(size).map(|c| c.to_vec()).collect()
+}

--- a/tiny-vllm-core/src/lib.rs
+++ b/tiny-vllm-core/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod cuda_utils;
+pub mod helpers;

--- a/tiny-vllm-py/src/lib.rs
+++ b/tiny-vllm-py/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use tiny_vllm_core::cuda_utils;
+use tiny_vllm_core::helpers;
 
 fn to_py_err(err: anyhow::Error) -> PyErr {
     pyo3::exceptions::PyRuntimeError::new_err(err.to_string())
@@ -25,5 +26,24 @@ fn tiny_vllm_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_device, m)?)?;
     m.add_function(wrap_pyfunction!(get_gpu_memory, m)?)?;
     m.add_function(wrap_pyfunction!(get_gpu_memory_utilization, m)?)?;
+    m.add_function(wrap_pyfunction!(clamp, m)?)?;
+    m.add_function(wrap_pyfunction!(flatten, m)?)?;
+    m.add_function(wrap_pyfunction!(chunked, m)?)?;
     Ok(())
 }
+
+#[pyfunction]
+fn clamp(value: i64, min_value: i64, max_value: i64) -> PyResult<i64> {
+    Ok(helpers::clamp(value, min_value, max_value))
+}
+
+#[pyfunction]
+fn flatten(list_of_lists: Vec<Vec<i64>>) -> PyResult<Vec<i64>> {
+    Ok(helpers::flatten(list_of_lists))
+}
+
+#[pyfunction]
+fn chunked(lst: Vec<i64>, size: usize) -> PyResult<Vec<Vec<i64>>> {
+    Ok(helpers::chunked(lst, size))
+}
+


### PR DESCRIPTION
## Summary
- implement helpers: `clamp`, `flatten`, and `chunked` in Rust core
- expose helpers through the PyO3 bindings
- add matching Python implementations for parity testing
- test helper parity in Python

## Testing
- `cargo test -p tiny-vllm-core`
- `cargo build -p tiny-vllm-py`
- `maturin build -m tiny-vllm-py/Cargo.toml`
- `pip install --force-reinstall --no-deps target/wheels/nano_vllm-0.2.0-cp311-cp311-manylinux_2_34_x86_64.whl`
- `PYTHONPATH=. pytest -q tests/python`

------
https://chatgpt.com/codex/tasks/task_e_685459e12fb8833186af890b0d962871