### PR TITLE
Port simple layers to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,13 +45,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
+name = "matrixmultiply"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
- "scopeguard",
+ "rawpointer",
 ]
 
 [[package]]
@@ -70,6 +70,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb929bc0da91a4d85ed6c0a84deaa53d411abfb387fc271124f91bf6b89f14e"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +137,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -163,25 +229,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.13"
+name = "rawpointer"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
-dependencies = [
- "bitflags",
-]
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -216,12 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
 name = "syn"
 version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +300,7 @@ name = "tiny-vllm-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ndarray",
  "serde",
  "serde_json",
 ]
@@ -252,6 +310,7 @@ name = "tiny-vllm-py"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "numpy",
  "pyo3",
  "tiny-vllm-core",
 ]

--- a/tests/python/test_activation.py
+++ b/tests/python/test_activation.py
@@ -1,0 +1,16 @@
+import numpy as np
+from tiny_vllm.model.layers import SiluAndMul
+
+
+def silu_and_mul_np(x: np.ndarray) -> np.ndarray:
+    half = x.shape[-1] // 2
+    a, b = x[:, :half], x[:, half:]
+    return (a / (1.0 + np.exp(-a))) * b
+
+
+def test_silu_and_mul_forward():
+    layer_rs = SiluAndMul()
+    x = np.random.randn(2, 8).astype(np.float32)
+    out_np = silu_and_mul_np(x)
+    out_rs = layer_rs.forward(x)
+    assert np.allclose(out_rs, out_np, atol=1e-5)

--- a/tests/python/test_linear.py
+++ b/tests/python/test_linear.py
@@ -1,0 +1,16 @@
+import numpy as np
+from tiny_vllm.model.layers import LinearLayer
+
+
+def linear_np(x: np.ndarray, weight: np.ndarray, bias: np.ndarray) -> np.ndarray:
+    return x @ weight.T + bias
+
+
+def test_linear_forward():
+    weight = np.random.randn(4, 3).astype(np.float32)
+    bias = np.random.randn(4).astype(np.float32)
+    layer = LinearLayer(weight, bias)
+    x = np.random.randn(2, 3).astype(np.float32)
+    y_rs = layer.forward(x)
+    y_np = linear_np(x, weight, bias)
+    assert np.allclose(y_rs, y_np, atol=1e-5)

--- a/tiny-vllm-core/Cargo.toml
+++ b/tiny-vllm-core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+ndarray = "0.16"

--- a/tiny-vllm-core/src/layers/activation.rs
+++ b/tiny-vllm-core/src/layers/activation.rs
@@ -1,0 +1,22 @@
+use ndarray::{Array2};
+
+#[derive(Debug, Default, Clone)]
+pub struct SiluAndMul;
+
+impl SiluAndMul {
+    pub fn forward(&self, input: &Array2<f32>) -> Array2<f32> {
+        let (batch, features) = input.dim();
+        assert!(features % 2 == 0, "input last dim must be even");
+        let half = features / 2;
+        let mut out = Array2::<f32>::zeros((batch, half));
+        for i in 0..batch {
+            for j in 0..half {
+                let x = input[(i, j)];
+                let y = input[(i, j + half)];
+                let silu = x * (1.0 / (1.0 + (-x).exp()));
+                out[(i, j)] = silu * y;
+            }
+        }
+        out
+    }
+}

--- a/tiny-vllm-core/src/layers/linear.rs
+++ b/tiny-vllm-core/src/layers/linear.rs
@@ -1,0 +1,21 @@
+use ndarray::{Array1, Array2};
+
+#[derive(Debug, Clone)]
+pub struct Linear {
+    pub weight: Array2<f32>,
+    pub bias: Option<Array1<f32>>,
+}
+
+impl Linear {
+    pub fn new(weight: Array2<f32>, bias: Option<Array1<f32>>) -> Self {
+        Self { weight, bias }
+    }
+
+    pub fn forward(&self, input: &Array2<f32>) -> Array2<f32> {
+        let mut y = input.dot(&self.weight.t());
+        if let Some(ref b) = self.bias {
+            y = y + b;
+        }
+        y
+    }
+}

--- a/tiny-vllm-core/src/layers/mod.rs
+++ b/tiny-vllm-core/src/layers/mod.rs
@@ -1,0 +1,2 @@
+pub mod activation;
+pub mod linear;

--- a/tiny-vllm-core/src/lib.rs
+++ b/tiny-vllm-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod cuda_utils;
 pub mod helpers;
+pub mod layers;

--- a/tiny-vllm-py/Cargo.toml
+++ b/tiny-vllm-py/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.22", features = ["extension-module"] }
 anyhow = "1"
 tiny-vllm-core = { path = "../tiny-vllm-core" }
+numpy = "0.22"

--- a/tiny-vllm-py/src/lib.rs
+++ b/tiny-vllm-py/src/lib.rs
@@ -1,7 +1,9 @@
 use pyo3::prelude::*;
-use tiny_vllm_core::cuda_utils;
+use pyo3::Bound;
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use tiny_vllm_core::helpers;
 use tiny_vllm_core::{config, cuda_utils};
+use tiny_vllm_core::layers::{activation::SiluAndMul as SiluCore, linear::Linear as LinearCore};
 
 
 fn to_py_err(err: anyhow::Error) -> PyErr {
@@ -88,7 +90,9 @@ fn tiny_vllm_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(default_kvcache_block_size, m)?)?;
     m.add_function(wrap_pyfunction!(default_num_kvcache_blocks, m)?)?;
     m.add_function(wrap_pyfunction!(default_eos, m)?)?;
-  
+    m.add_class::<LinearLayer>()?;
+    m.add_class::<SiluAndMul>()?;
+
     Ok(())
 }
 
@@ -107,3 +111,43 @@ fn chunked(lst: Vec<i64>, size: usize) -> PyResult<Vec<Vec<i64>>> {
     Ok(helpers::chunked(lst, size))
 }
 
+
+#[pyclass]
+struct LinearLayer {
+    inner: LinearCore,
+}
+
+#[pymethods]
+impl LinearLayer {
+    #[new]
+    fn new(weight: PyReadonlyArray2<f32>, bias: Option<PyReadonlyArray1<f32>>) -> Self {
+        let weight = weight.as_array().to_owned();
+        let bias = bias.map(|b| b.as_array().to_owned());
+        Self { inner: LinearCore::new(weight, bias) }
+    }
+
+    fn forward<'py>(&self, py: Python<'py>, x: PyReadonlyArray2<f32>) -> Bound<'py, PyArray2<f32>> {
+        let x = x.as_array().to_owned();
+        let y = self.inner.forward(&x);
+        y.into_pyarray_bound(py)
+    }
+}
+
+#[pyclass]
+struct SiluAndMul {
+    inner: SiluCore,
+}
+
+#[pymethods]
+impl SiluAndMul {
+    #[new]
+    fn new() -> Self {
+        Self { inner: SiluCore::default() }
+    }
+
+    fn forward<'py>(&self, py: Python<'py>, x: PyReadonlyArray2<f32>) -> Bound<'py, PyArray2<f32>> {
+        let x = x.as_array().to_owned();
+        let y = self.inner.forward(&x);
+        y.into_pyarray_bound(py)
+    }
+}

--- a/tiny_vllm/model/layers.py
+++ b/tiny_vllm/model/layers.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from tiny_vllm_py import LinearLayer, SiluAndMul
+
+__all__ = ["LinearLayer", "SiluAndMul"]


### PR DESCRIPTION
## Summary
- port SiluAndMul activation and Linear layer to Rust
- expose the layers via PyO3 bindings
- add Python re-export `tiny_vllm.model.layers`
- implement parity tests using numpy

## Testing
- `cargo check --workspace`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685552152d808331ad5a84b7d6dfe801