### PR TITLE
Add network skeleton in Rust

### DIFF
--- a/tiny-vllm-core/src/lib.rs
+++ b/tiny-vllm-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod cuda_utils;
 pub mod helpers;
+pub mod network;

--- a/tiny-vllm-core/src/network.rs
+++ b/tiny-vllm-core/src/network.rs
@@ -1,0 +1,80 @@
+//! Neural network assembly and forward pass logic.
+//!
+//! This is a very small placeholder implementation used during the
+//! early stages of the Rust port.  It mimics the Python
+//! `tiny_vllm.model.network` module by providing a sequential network
+//! structure that owns a list of layers.  Real layers and GPU execution
+//! will be implemented in later epochs.
+
+use std::sync::Arc;
+
+/// Lightweight tensor type used for testing the network plumbing.  It
+/// simply stores a flat vector of `f32` values.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Tensor {
+    pub data: Vec<f32>,
+}
+
+impl Tensor {
+    /// Create a new tensor from raw data.
+    pub fn new(data: Vec<f32>) -> Self {
+        Self { data }
+    }
+}
+
+/// Trait implemented by all network layers.
+pub trait Layer: Send + Sync {
+    fn forward(&self, input: Tensor) -> Tensor;
+}
+
+/// Identity layer used as a default placeholder.  It simply returns the
+/// input tensor unchanged.
+pub struct IdentityLayer;
+
+impl Layer for IdentityLayer {
+    fn forward(&self, input: Tensor) -> Tensor {
+        input
+    }
+}
+
+/// Sequential network holding an ordered list of layers.  During the
+/// forward pass each layer receives the output of the previous one.
+pub struct Network {
+    layers: Vec<Arc<dyn Layer>>,
+}
+
+impl Network {
+    /// Create an empty network.
+    pub fn new() -> Self {
+        Self { layers: Vec::new() }
+    }
+
+    /// Append a layer to the network.
+    pub fn add_layer<L: Layer + 'static>(&mut self, layer: L) {
+        self.layers.push(Arc::new(layer));
+    }
+
+    /// Execute the forward pass over all layers.
+    pub fn forward(&self, mut input: Tensor) -> Tensor {
+        for layer in &self.layers {
+            input = layer.forward(input);
+        }
+        input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identity_network() {
+        let mut net = Network::new();
+        net.add_layer(IdentityLayer);
+        net.add_layer(IdentityLayer);
+
+        let input = Tensor::new(vec![1.0, 2.0, 3.0]);
+        let output = net.forward(input.clone());
+        assert_eq!(output, input);
+    }
+}

--- a/tiny-vllm-py/src/lib.rs
+++ b/tiny-vllm-py/src/lib.rs
@@ -1,8 +1,6 @@
 use pyo3::prelude::*;
-use tiny_vllm_core::cuda_utils;
 use tiny_vllm_core::helpers;
-use tiny_vllm_core::{config, cuda_utils};
-
+use tiny_vllm_core::{config, cuda_utils, network};
 
 fn to_py_err(err: anyhow::Error) -> PyErr {
     pyo3::exceptions::PyRuntimeError::new_err(err.to_string())
@@ -69,6 +67,32 @@ fn default_eos() -> i64 {
     config::settings::EOS
 }
 
+// ----- Simple network bindings -----
+#[pyclass]
+struct Network {
+    inner: network::Network,
+}
+
+#[pymethods]
+impl Network {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: network::Network::new(),
+        }
+    }
+
+    fn add_identity_layer(&mut self) {
+        self.inner.add_layer(network::IdentityLayer);
+    }
+
+    fn forward(&self, input: Vec<f32>) -> Vec<f32> {
+        let tensor = network::Tensor::new(input);
+        let output = self.inner.forward(tensor);
+        output.data
+    }
+}
+
 #[pymodule]
 fn tiny_vllm_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_device, m)?)?;
@@ -88,7 +112,9 @@ fn tiny_vllm_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(default_kvcache_block_size, m)?)?;
     m.add_function(wrap_pyfunction!(default_num_kvcache_blocks, m)?)?;
     m.add_function(wrap_pyfunction!(default_eos, m)?)?;
-  
+
+    m.add_class::<Network>()?;
+
     Ok(())
 }
 
@@ -106,4 +132,3 @@ fn flatten(list_of_lists: Vec<Vec<i64>>) -> PyResult<Vec<i64>> {
 fn chunked(lst: Vec<i64>, size: usize) -> PyResult<Vec<Vec<i64>>> {
     Ok(helpers::chunked(lst, size))
 }
-


### PR DESCRIPTION
## Summary
- implement a very small sequential network in Rust
- expose the network via `tiny_vllm_py` bindings
- allow constructing a dummy network and running a forward pass

## Testing
- `cargo test --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855526c212c833190d6884906e09265