### PR TITLE
Add engine parallel stub

### DIFF
--- a/tiny-vllm-core/src/engine/mod.rs
+++ b/tiny-vllm-core/src/engine/mod.rs
@@ -1,0 +1,4 @@
+//! Engine utilities for parallel execution.
+
+pub mod parallel;
+

--- a/tiny-vllm-core/src/engine/parallel.rs
+++ b/tiny-vllm-core/src/engine/parallel.rs
@@ -7,17 +7,22 @@
 
 use std::sync::{Mutex, OnceLock};
 
-#[derive(Debug, Default, Clone, Copy)]
-struct ParallelState {
-    world_size: usize,
-    rank: usize,
-    initialized: bool,
+use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
+
+static WORLD_SIZE: OnceLock<AtomicUsize> = OnceLock::new();
+static RANK: OnceLock<AtomicUsize> = OnceLock::new();
+static INITIALIZED: OnceLock<AtomicBool> = OnceLock::new();
+
+fn world_size() -> &'static AtomicUsize {
+    WORLD_SIZE.get_or_init(|| AtomicUsize::new(1))
 }
 
-static STATE: OnceLock<Mutex<ParallelState>> = OnceLock::new();
+fn rank() -> &'static AtomicUsize {
+    RANK.get_or_init(|| AtomicUsize::new(0))
+}
 
-fn state() -> &'static Mutex<ParallelState> {
-    STATE.get_or_init(|| Mutex::new(ParallelState::default()))
+fn initialized() -> &'static AtomicBool {
+    INITIALIZED.get_or_init(|| AtomicBool::new(false))
 }
 
 /// Initialize the parallel runtime.

--- a/tiny-vllm-core/src/engine/parallel.rs
+++ b/tiny-vllm-core/src/engine/parallel.rs
@@ -1,0 +1,75 @@
+//! Stubbed parallel execution utilities.
+//!
+//! This module provides minimal implementations of the parallel primitives
+//! used throughout the engine. The real implementation will provide true
+//! distributed execution backed by CUDA/NCCL. For now we simply maintain the
+//! world size and rank in-process and perform no communication.
+
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ParallelState {
+    world_size: usize,
+    rank: usize,
+    initialized: bool,
+}
+
+static STATE: OnceLock<Mutex<ParallelState>> = OnceLock::new();
+
+fn state() -> &'static Mutex<ParallelState> {
+    STATE.get_or_init(|| Mutex::new(ParallelState::default()))
+}
+
+/// Initialize the parallel runtime.
+///
+/// In this stub implementation we simply record the provided rank and
+/// world size. The real implementation will set up inter-process
+/// communication.
+pub fn init_process_group(world_size: usize, rank: usize) {
+    let mut s = state().lock().unwrap();
+    s.world_size = world_size.max(1);
+    s.rank = rank.min(world_size.saturating_sub(1));
+    s.initialized = true;
+}
+
+/// Destroy the parallel runtime, resetting it to defaults.
+pub fn destroy_process_group() {
+    let mut s = state().lock().unwrap();
+    *s = ParallelState::default();
+}
+
+/// Return the world size of the current process group.
+pub fn get_world_size() -> usize {
+    let s = state().lock().unwrap();
+    if s.initialized { s.world_size } else { 1 }
+}
+
+/// Return the rank of the current process within the process group.
+pub fn get_rank() -> usize {
+    let s = state().lock().unwrap();
+    if s.initialized { s.rank } else { 0 }
+}
+
+/// Synchronize all processes. In the stub this is a no-op.
+pub fn barrier() {
+    // no-op
+}
+
+/// Perform an all-reduce operation on `value` in-place.
+///
+/// The stub implementation leaves `value` unchanged.
+pub fn all_reduce<T>(_value: &mut T) {
+    // no-op
+}
+
+/// Gather `input` to `output` on the `root` process.
+///
+/// The stub simply clones `input` into `output` when called on the root.
+pub fn gather<T: Clone>(input: &T, output: Option<&mut Vec<T>>, root: usize) {
+    if get_rank() == root {
+        if let Some(out) = output {
+            out.push(input.clone());
+        }
+    }
+}
+

--- a/tiny-vllm-core/src/helpers.rs
+++ b/tiny-vllm-core/src/helpers.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 
 /// Clamp `value` to the inclusive range [min_value, max_value].
 pub fn clamp(value: i64, min_value: i64, max_value: i64) -> i64 {

--- a/tiny-vllm-core/src/lib.rs
+++ b/tiny-vllm-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod cuda_utils;
 pub mod helpers;
+pub mod engine;

--- a/tiny-vllm-py/src/lib.rs
+++ b/tiny-vllm-py/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
-use tiny_vllm_core::cuda_utils;
 use tiny_vllm_core::helpers;
 use tiny_vllm_core::{config, cuda_utils};
+use tiny_vllm_core::engine::parallel;
 
 
 fn to_py_err(err: anyhow::Error) -> PyErr {
@@ -21,6 +21,32 @@ fn get_gpu_memory() -> PyResult<u64> {
 #[pyfunction]
 fn get_gpu_memory_utilization() -> PyResult<f32> {
     cuda_utils::get_gpu_memory_utilization().map_err(to_py_err)
+}
+
+// ----- Parallel helpers -----
+#[pyfunction]
+fn init_process_group(world_size: usize, rank: usize) {
+    parallel::init_process_group(world_size, rank);
+}
+
+#[pyfunction]
+fn destroy_process_group() {
+    parallel::destroy_process_group();
+}
+
+#[pyfunction]
+fn get_rank() -> usize {
+    parallel::get_rank()
+}
+
+#[pyfunction]
+fn get_world_size() -> usize {
+    parallel::get_world_size()
+}
+
+#[pyfunction]
+fn barrier() {
+    parallel::barrier();
 }
 
 // ----- Default settings helpers -----
@@ -77,6 +103,12 @@ fn tiny_vllm_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(clamp, m)?)?;
     m.add_function(wrap_pyfunction!(flatten, m)?)?;
     m.add_function(wrap_pyfunction!(chunked, m)?)?;
+    // parallel helpers
+    m.add_function(wrap_pyfunction!(init_process_group, m)?)?;
+    m.add_function(wrap_pyfunction!(destroy_process_group, m)?)?;
+    m.add_function(wrap_pyfunction!(get_rank, m)?)?;
+    m.add_function(wrap_pyfunction!(get_world_size, m)?)?;
+    m.add_function(wrap_pyfunction!(barrier, m)?)?;
 
     // default setting helpers
     m.add_function(wrap_pyfunction!(default_max_num_batched_tokens, m)?)?;


### PR DESCRIPTION
## Summary
- add stubbed parallel execution module in Rust core
- expose parallel helpers through the Python bindings
- cleanup unused import

## Testing
- `cargo check -p tiny-vllm-core`
- `cargo check -p tiny-vllm-py`
- `cargo test -p tiny-vllm-core`
- `cargo test -p tiny-vllm-py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tiny_vllm_py')*

------
https://chatgpt.com/codex/tasks/task_e_6855529d4e148331bed4f55972551571