### PR TITLE
Add Rust engine scaffolding

### DIFF
--- a/tests/python/test_epoch04_engine.py
+++ b/tests/python/test_epoch04_engine.py
@@ -1,0 +1,5 @@
+import tiny_vllm.engine as engine
+
+def test_engine_init():
+    e = engine.Engine(num_threads=3)
+    assert e.num_threads == 3

--- a/tiny-vllm-core/src/engine/mod.rs
+++ b/tiny-vllm-core/src/engine/mod.rs
@@ -1,4 +1,47 @@
-//! Engine utilities for parallel execution.
+//! Engine utilities for model execution.
+
+use std::sync::OnceLock;
 
 pub mod parallel;
+
+/// Core inference engine responsible for running models.
+#[derive(Debug)]
+pub struct Engine {
+    num_threads: usize,
+}
+
+impl Engine {
+    /// Create a new engine instance using the provided number of threads.
+    pub fn new(num_threads: usize) -> Self {
+        Self { num_threads: num_threads.max(1) }
+    }
+
+    /// Return the number of worker threads used by the engine.
+    pub fn num_threads(&self) -> usize {
+        self.num_threads
+    }
+}
+
+static GLOBAL_ENGINE: OnceLock<Engine> = OnceLock::new();
+
+/// Initialize a global engine with the given number of threads.
+pub fn init_global(num_threads: usize) {
+    let _ = GLOBAL_ENGINE.set(Engine::new(num_threads));
+}
+
+/// Get a reference to the global engine, initializing it on first use with one thread.
+pub fn global() -> &'static Engine {
+    GLOBAL_ENGINE.get_or_init(|| Engine::new(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_engine_basic() {
+        let engine = Engine::new(4);
+        assert_eq!(engine.num_threads(), 4);
+    }
+}
 

--- a/tiny-vllm-core/src/lib.rs
+++ b/tiny-vllm-core/src/lib.rs
@@ -5,4 +5,3 @@ pub mod model;
 pub mod engine;
 pub mod network;
 pub mod layers;
-pub mod model;

--- a/tiny-vllm-py/src/lib.rs
+++ b/tiny-vllm-py/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use tiny_vllm_core::{config, cuda_utils, model::layers};
+use tiny_vllm_core::engine;
 use tiny_vllm_core::helpers;
 use tiny_vllm_core::helpers;
 use tiny_vllm_core::{config, cuda_utils};
@@ -127,6 +128,27 @@ impl Network {
         let tensor = network::Tensor::new(input);
         let output = self.inner.forward(tensor);
         output.data
+    }
+}
+
+#[pyclass]
+struct Engine {
+    inner: engine::Engine,
+}
+
+#[pymethods]
+impl Engine {
+    #[new]
+    fn new(num_threads: Option<usize>) -> Self {
+        let threads = num_threads.unwrap_or(1);
+        Self { inner: engine::Engine::new(threads) }
+    }
+
+    #[getter]
+    fn num_threads(&self) -> usize {
+        self.inner.num_threads()
+    }
+}
 
 #[pyclass]
 struct Model {
@@ -181,6 +203,7 @@ fn tiny_vllm_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<RMSNorm>()?;
 
     m.add_class::<Network>()?;
+    m.add_class::<Engine>()?;
 
     m.add_class::<LinearLayer>()?;
     m.add_class::<SiluAndMul>()?;

--- a/tiny_vllm/__init__.py
+++ b/tiny_vllm/__init__.py
@@ -1,4 +1,5 @@
 from . import config
 from .model import layers
+from . import engine
 
-__all__ = ["config", "layers"]
+__all__ = ["config", "layers", "engine"]

--- a/tiny_vllm/engine/__init__.py
+++ b/tiny_vllm/engine/__init__.py
@@ -1,0 +1,5 @@
+import tiny_vllm_py as _rust
+
+Engine = _rust.Engine
+
+__all__ = ["Engine"]


### PR DESCRIPTION
## Summary
- expose new `engine.Engine` struct in Rust with basic thread config
- provide Python bindings and top-level re-exports
- add simple test for engine init

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' etc.)*
- `cargo test -p tiny-vllm-core` *(fails: failed to parse lock file)*

------
https://chatgpt.com/codex/tasks/task_e_6855f403c5188331b02a81c83ff04fbc