### PR TITLE
Add stubbed model runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "candle-core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f51e2ecf6efe9737af8f993433c839f956d2b6ed4fd2dd4a7c6d8b0fa667ff"
+dependencies = [
+ "byteorder",
+ "gemm 0.17.1",
+ "half",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror",
+ "ug",
+ "yoke",
+ "zip",
+]
 
 [[package]]
 name = "cfg-if"
@@ -21,10 +90,400 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e53799688f5632f364f8fb387488dd05db9fe45db7011be066fc20e7027f8b"
+dependencies = [
+ "bytemuck",
+ "reborrow",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490bd48eb68fffcfed519b4edbfd82c69cbe741d175b84f0e0cbe8c57cbe0bdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "gemm"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab24cc62135b40090e31a76a9b2766a501979f3070fa27f689c27ec04377d32"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-c32 0.17.1",
+ "gemm-c64 0.17.1",
+ "gemm-common 0.17.1",
+ "gemm-f16 0.17.1",
+ "gemm-f32 0.17.1",
+ "gemm-f64 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-c32 0.18.2",
+ "gemm-c64 0.18.2",
+ "gemm-common 0.18.2",
+ "gemm-f16 0.18.2",
+ "gemm-f32 0.18.2",
+ "gemm-f64 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c030d0b983d1e34a546b86e08f600c11696fde16199f971cd46c12e67512c0"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb5f2e79fefb9693d18e1066a557b4546cd334b226beadc68b11a8f9431852a"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.10.0",
+ "half",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.18.22",
+ "raw-cpuid 10.7.0",
+ "rayon",
+ "seq-macro",
+ "sysctl 0.5.5",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.13.0",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.21.5",
+ "raw-cpuid 11.5.0",
+ "rayon",
+ "seq-macro",
+ "sysctl 0.6.0",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca4c06b9b11952071d317604acb332e924e817bd891bec8dfb494168c7cedd4"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "gemm-f32 0.17.1",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a69f51aaefbd9cf12d18faf273d3e982d9d711f60775645ed5c8047b4ae113"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa397a48544fadf0b81ec8741e5c0fba0043008113f71f2034def1935645d2b0"
+dependencies = [
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "rand",
+ "rand_distr",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indoc"
@@ -45,6 +504,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +534,16 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "memoffset"
@@ -85,11 +570,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -103,12 +613,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -133,6 +698,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,12 +725,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulp"
+version = "0.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-complex",
+ "reborrow",
+]
+
+[[package]]
+name = "pulp"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
 ]
 
 [[package]]
@@ -229,10 +850,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "rustc-hash"
@@ -241,10 +951,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safetensors"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -279,6 +1020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,16 +1037,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+dependencies = [
+ "bitflags 2.9.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.9.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tiny-vllm-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "candle-core",
  "ndarray",
  "serde",
  "serde_json",
@@ -318,6 +1125,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "ug"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b70b37e9074642bc5f60bb23247fd072a84314ca9e71cdf8527593406a0dd3"
+dependencies = [
+ "gemm 0.18.2",
+ "half",
+ "libloading",
+ "memmap2",
+ "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror",
+ "tracing",
+ "yoke",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +1206,276 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap",
+ "num_enum",
+ "thiserror",
+]

--- a/tiny-vllm-core/Cargo.toml
+++ b/tiny-vllm-core/Cargo.toml
@@ -9,3 +9,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ndarray = "0.16"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
+candle-core = "0.9"

--- a/tiny-vllm-core/src/config.rs
+++ b/tiny-vllm-core/src/config.rs
@@ -54,6 +54,46 @@ impl Default for VllmConfig {
     }
 }
 
+/// Configuration used by the [`ModelRunner`]. This is a small wrapper around
+/// [`VllmConfig`] with a couple of convenience builder methods used in tests.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub device: String,
+    pub dtype: String,
+    pub kvcache_block_size: usize,
+    pub num_kvcache_blocks: Option<usize>,
+    pub enforce_eager: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            device: "cpu".to_string(),
+            dtype: "float32".to_string(),
+            kvcache_block_size: settings::KVCACHE_BLOCK_SIZE,
+            num_kvcache_blocks: None,
+            enforce_eager: settings::ENFORCE_EAGER,
+        }
+    }
+}
+
+impl Config {
+    pub fn with_device(mut self, dev: &str) -> Self {
+        self.device = dev.to_string();
+        self
+    }
+
+    pub fn with_dtype(mut self, dt: &str) -> Self {
+        self.dtype = dt.to_string();
+        self
+    }
+
+    pub fn with_max_num_seqs(self, _n: usize) -> Self {
+        // field not used in the simplified implementation
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tiny-vllm-core/src/engine/model_runner.rs
+++ b/tiny-vllm-core/src/engine/model_runner.rs
@@ -1,3 +1,232 @@
-//! Placeholder for `nanovllm.engine.model_runner`.
+//! Model runner for executing inference with optimizations
+//!
+//! This module provides a lightweight `ModelRunner` capable of executing a
+//! forward pass on the stub Qwen3 model.  The implementation mirrors the API of
+//! the original project but keeps allocations to a minimum.
 
-// Implementation will be provided in future epochs.
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use candle_core::{Tensor, Device, DType};
+use anyhow::Result;
+
+use crate::config::Config;
+use crate::models::qwen3::{Qwen3Model, Qwen3Config};
+use crate::engine::sequence::Sequence;
+use crate::utils::context::{Context, set_context};
+use crate::layers::sampler::Sampler;
+
+/// Model runner for executing inference
+#[derive(Debug)]
+pub struct ModelRunner {
+    model: Qwen3Model,
+    sampler: Sampler,
+    k_caches: Vec<Arc<Tensor>>,
+    v_caches: Vec<Arc<Tensor>>,
+    block_size: usize,
+    num_blocks: usize,
+    device: Device,
+    dtype: DType,
+    cuda_graphs_enabled: bool,
+    cuda_graphs: HashMap<usize, CudaGraph>,
+}
+
+#[derive(Debug)]
+struct CudaGraph {
+    batch_size: usize,
+    input_tensors: Vec<Tensor>,
+    output_tensors: Vec<Tensor>,
+    is_captured: bool,
+}
+
+impl ModelRunner {
+    pub fn new(config: &Config) -> Result<Self> {
+        let device = Self::get_device(&config.device)?;
+        let dtype = Self::get_dtype(&config.dtype)?;
+        let model_config = Qwen3Config::from_config(&Config::default());
+        let model = Qwen3Model::new(model_config.clone(), 0, &device, dtype)?;
+        let sampler = Sampler::new(&device);
+        let (k, v) = Self::create_kv_cache(&model_config, config.num_kvcache_blocks.unwrap_or(1), config.kvcache_block_size, &device, dtype)?;
+        Ok(Self { model, sampler, k_caches: k, v_caches: v, block_size: config.kvcache_block_size, num_blocks: config.num_kvcache_blocks.unwrap_or(1), device, dtype, cuda_graphs_enabled: !config.enforce_eager, cuda_graphs: HashMap::new() })
+    }
+
+    pub fn execute_model(&mut self, sequences: &[Sequence], is_prefill: bool) -> Result<Tensor> {
+        let (input_ids, position_ids) = self.prepare_inputs(sequences, is_prefill)?;
+        let ctx = self.create_context(sequences, is_prefill)?;
+        set_context(ctx)?;
+        let logits = self.model.forward(&input_ids, &position_ids)?;
+        Ok(logits)
+    }
+
+    pub fn sample_tokens(&self, logits: &Tensor, sequences: &[Sequence]) -> Result<Vec<i64>> {
+        let params: Vec<_> = sequences.iter().map(|s| s.sampling_params.clone()).collect();
+        let t = self.sampler.batch_sample(logits, &params)?;
+        Ok(t.to_vec1::<i64>()?)
+    }
+
+    fn prepare_inputs(&self, sequences: &[Sequence], is_prefill: bool) -> Result<(Tensor, Tensor)> {
+        if is_prefill { self.prepare_prefill_inputs(sequences) } else { self.prepare_decode_inputs(sequences) }
+    }
+
+    fn prepare_prefill_inputs(&self, sequences: &[Sequence]) -> Result<(Tensor, Tensor)> {
+        let mut all_input = Vec::new();
+        let mut all_pos = Vec::new();
+        for seq in sequences {
+            let ids = seq.all_token_ids();
+            all_input.extend_from_slice(ids);
+            all_pos.extend(0..ids.len() as i64);
+        }
+        let len = all_input.len();
+        let ids = Tensor::from_vec(all_input, (len,), &self.device)?;
+        let pos = Tensor::from_vec(all_pos, (len,), &self.device)?;
+        Ok((ids, pos))
+    }
+
+    fn prepare_decode_inputs(&self, sequences: &[Sequence]) -> Result<(Tensor, Tensor)> {
+        let batch = sequences.len();
+        let ids: Vec<i64> = sequences.iter().map(|s| s.last_token).collect();
+        let pos: Vec<i64> = sequences.iter().map(|s| s.len() as i64 - 1).collect();
+        let ids = Tensor::from_vec(ids, (batch,), &self.device)?;
+        let pos = Tensor::from_vec(pos, (batch,), &self.device)?;
+        Ok((ids, pos))
+    }
+
+    fn create_context(&self, sequences: &[Sequence], is_prefill: bool) -> Result<Context> {
+        if is_prefill { self.create_prefill_context(sequences) } else { self.create_decode_context(sequences) }
+    }
+
+    fn create_prefill_context(&self, sequences: &[Sequence]) -> Result<Context> {
+        let mut cu_q = vec![0i64];
+        let mut cu_k = vec![0i64];
+        let mut slot = Vec::new();
+        let mut cur = 0;
+        let mut max_q = 0;
+        let mut max_k = 0;
+        for seq in sequences {
+            let l = seq.len();
+            cur += l;
+            cu_q.push(cur as i64);
+            cu_k.push(cur as i64);
+            max_q = max_q.max(l);
+            max_k = max_k.max(l);
+            slot.extend(0..l as i64);
+        }
+        let cu_q_t = Tensor::from_vec(cu_q, (sequences.len()+1,), &self.device)?;
+        let cu_k_t = Tensor::from_vec(cu_k, (sequences.len()+1,), &self.device)?;
+        let slot_t = Tensor::from_vec(slot, (cur,), &self.device)?;
+        Ok(Context::prefill(cu_q_t, cu_k_t, max_q, max_k, slot_t, None))
+    }
+
+    fn create_decode_context(&self, sequences: &[Sequence]) -> Result<Context> {
+        let bs = sequences.len();
+        let slot: Vec<i64> = (0..bs as i64).collect();
+        let ctx_len: Vec<i64> = sequences.iter().map(|s| s.len() as i64).collect();
+        let max_blocks = sequences.iter().map(|s| s.num_blocks()).max().unwrap_or(1);
+        let mut tables = Vec::new();
+        for seq in sequences {
+            let mut blocks: Vec<i64> = seq.block_table.iter().map(|&b| b as i64).collect();
+            while blocks.len() < max_blocks { blocks.push(-1); }
+            tables.extend(blocks);
+        }
+        let slot_t = Tensor::from_vec(slot, (bs,), &self.device)?;
+        let ctx_t = Tensor::from_vec(ctx_len, (bs,), &self.device)?;
+        let table_t = Tensor::from_vec(tables, (bs, max_blocks), &self.device)?;
+        Ok(Context::decode(slot_t, ctx_t, table_t))
+    }
+
+    fn create_kv_cache(config: &Qwen3Config, num_blocks: usize, block_size: usize, device: &Device, dtype: DType) -> Result<(Vec<Arc<Tensor>>, Vec<Arc<Tensor>>)> {
+        let num_layers = config.num_hidden_layers;
+        let num_kv_heads = config.num_key_value_heads / config.tensor_parallel_size;
+        let head_dim = config.head_dim();
+        let mut k_caches = Vec::new();
+        let mut v_caches = Vec::new();
+        for _ in 0..num_layers {
+            let k = Tensor::zeros((num_blocks, block_size, num_kv_heads, head_dim), dtype, device)?;
+            let v = Tensor::zeros((num_blocks, block_size, num_kv_heads, head_dim), dtype, device)?;
+            k_caches.push(Arc::new(k));
+            v_caches.push(Arc::new(v));
+        }
+        Ok((k_caches, v_caches))
+    }
+
+    fn get_device(s: &str) -> Result<Device> {
+        match s {
+            "cpu" => Ok(Device::Cpu),
+            _ => Err(anyhow::anyhow!("unsupported device")),
+        }
+    }
+
+    fn get_dtype(s: &str) -> Result<DType> {
+        match s {
+            "float32" | "f32" => Ok(DType::F32),
+            "float16" | "f16" => Ok(DType::F16),
+            "bfloat16" | "bf16" => Ok(DType::BF16),
+            _ => Err(anyhow::anyhow!("unsupported dtype")),
+        }
+    }
+
+    pub fn config(&self) -> &Qwen3Config { self.model.config() }
+    pub fn device(&self) -> &Device { &self.device }
+    pub fn dtype(&self) -> DType { self.dtype }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sampling_params::SamplingParams;
+
+    fn create_test_config() -> Config {
+        Config::default().with_device("cpu").with_dtype("float32").with_max_num_seqs(4)
+    }
+
+    #[test]
+    fn test_model_runner_creation() {
+        let config = create_test_config();
+        let runner = ModelRunner::new(&config).unwrap();
+        assert!(matches!(*runner.device(), Device::Cpu));
+        assert_eq!(runner.dtype(), DType::F32);
+    }
+
+    #[test]
+    fn test_device_parsing() {
+        assert!(matches!(ModelRunner::get_device("cpu").unwrap(), Device::Cpu));
+        assert!(ModelRunner::get_device("invalid").is_err());
+    }
+
+    #[test]
+    fn test_dtype_parsing() {
+        assert_eq!(ModelRunner::get_dtype("float32").unwrap(), DType::F32);
+        assert_eq!(ModelRunner::get_dtype("f32").unwrap(), DType::F32);
+        assert!(ModelRunner::get_dtype("invalid").is_err());
+    }
+
+    #[test]
+    fn test_prepare_decode_inputs() {
+        let config = create_test_config();
+        let runner = ModelRunner::new(&config).unwrap();
+        let sequences = vec![
+            Sequence::new(vec![1,2,3], SamplingParams::default()),
+            Sequence::new(vec![4,5], SamplingParams::default()),
+        ];
+        let (ids, pos) = runner.prepare_decode_inputs(&sequences).unwrap();
+        assert_eq!(ids.dims(), [2]);
+        assert_eq!(pos.dims(), [2]);
+        let id_vals: Vec<i64> = ids.to_vec1().unwrap();
+        let pos_vals: Vec<i64> = pos.to_vec1().unwrap();
+        assert_eq!(id_vals, vec![3,5]);
+        assert_eq!(pos_vals, vec![2,1]);
+    }
+
+    #[test]
+    fn test_kv_cache_creation() {
+        let config = Qwen3Config::default();
+        let device = Device::Cpu;
+        let dtype = DType::F32;
+        let (k,v) = ModelRunner::create_kv_cache(&config, 100, 16, &device, dtype).unwrap();
+        assert_eq!(k.len(), config.num_hidden_layers);
+        assert_eq!(v.len(), config.num_hidden_layers);
+        let expected = [100,16, config.num_key_value_heads, config.head_dim()];
+        assert_eq!(k[0].dims(), expected);
+        assert_eq!(v[0].dims(), expected);
+    }
+}

--- a/tiny-vllm-core/src/engine/model_runner.rs
+++ b/tiny-vllm-core/src/engine/model_runner.rs
@@ -43,7 +43,7 @@ impl ModelRunner {
     pub fn new(config: &Config) -> Result<Self> {
         let device = Self::get_device(&config.device)?;
         let dtype = Self::get_dtype(&config.dtype)?;
-        let model_config = Qwen3Config::from_config(&Config::default());
+        let model_config = Qwen3Config::from_config(config);
         let model = Qwen3Model::new(model_config.clone(), 0, &device, dtype)?;
         let sampler = Sampler::new(&device);
         let (k, v) = Self::create_kv_cache(&model_config, config.num_kvcache_blocks.unwrap_or(1), config.kvcache_block_size, &device, dtype)?;

--- a/tiny-vllm-core/src/engine/sequence.rs
+++ b/tiny-vllm-core/src/engine/sequence.rs
@@ -1,3 +1,47 @@
-//! Placeholder for `nanovllm.engine.sequence`.
+//! Sequence utilities for inference
+//!
+//! This module contains a lightweight `Sequence` type used by the
+//! `ModelRunner`. The structure closely mirrors the Python implementation
+//! but only exposes the functionality required by the current Rust code.
 
-// Implementation will be provided in future epochs.
+use crate::sampling_params::SamplingParams;
+
+/// Representation of a single token sequence.
+#[derive(Debug, Clone)]
+pub struct Sequence {
+    token_ids: Vec<i64>,
+    /// ID of the last token in the sequence.
+    pub last_token: i64,
+    /// Mapping of blocks allocated for the KV cache.
+    pub block_table: Vec<i32>,
+    /// Parameters used for sampling new tokens.
+    pub sampling_params: SamplingParams,
+}
+
+impl Sequence {
+    /// Create a new sequence from the provided tokens and sampling parameters.
+    pub fn new(token_ids: Vec<i64>, sampling_params: SamplingParams) -> Self {
+        let last_token = *token_ids.last().unwrap_or(&-1);
+        Self { token_ids, last_token, block_table: Vec::new(), sampling_params }
+    }
+
+    /// Return the total number of tokens in the sequence.
+    pub fn len(&self) -> usize {
+        self.token_ids.len()
+    }
+
+    /// Return all token ids as a slice without additional allocation.
+    pub fn all_token_ids(&self) -> &[i64] {
+        &self.token_ids
+    }
+
+    /// Number of KV cache blocks used by this sequence.
+    pub fn num_blocks(&self) -> usize {
+        (self.len() + Self::block_size() - 1) / Self::block_size()
+    }
+
+    /// Block size in tokens.
+    pub fn block_size() -> usize {
+        256
+    }
+}

--- a/tiny-vllm-core/src/layers/sampler.rs
+++ b/tiny-vllm-core/src/layers/sampler.rs
@@ -1,3 +1,25 @@
-//! Placeholder for `nanovllm.layers.sampler`.
+//! Simplified token sampler.
+//!
+//! The real project implements a sophisticated sampling kernel.  For our
+//! purposes a very small stub is sufficient.
 
-// Implementation will be provided in future epochs.
+use candle_core::{Device, Tensor, DType, Result as CandleResult};
+use crate::sampling_params::SamplingParams;
+
+#[derive(Debug)]
+pub struct Sampler {
+    _device: Device,
+}
+
+impl Sampler {
+    pub fn new(device: &Device) -> Self {
+        Self { _device: device.clone() }
+    }
+
+    /// Sample tokens from the provided logits.
+    pub fn batch_sample(&self, logits: &Tensor, params: &[SamplingParams]) -> CandleResult<Tensor> {
+        // This stub simply selects token zero for every batch element.
+        let bs = params.len();
+        Tensor::zeros((bs,), DType::I64, logits.device())
+    }
+}

--- a/tiny-vllm-core/src/models/qwen3.rs
+++ b/tiny-vllm-core/src/models/qwen3.rs
@@ -1,3 +1,48 @@
-//! Placeholder for `nanovllm.models.qwen3`.
+//! Minimal Qwen3 model stubs.
+//!
+//! These structures only provide the functionality required for the
+//! `ModelRunner` tests and are not meant to implement the real model.
 
-// Implementation will be provided in future epochs.
+use candle_core::{Tensor, Device, DType, Result as CandleResult};
+
+#[derive(Debug, Clone)]
+pub struct Qwen3Config {
+    pub num_hidden_layers: usize,
+    pub num_key_value_heads: usize,
+    pub tensor_parallel_size: usize,
+    pub head_dim: usize,
+}
+
+impl Qwen3Config {
+    pub fn from_config<_C>(_config: &_C) -> Self {
+        Self { num_hidden_layers: 2, num_key_value_heads: 2, tensor_parallel_size: 1, head_dim: 64 }
+    }
+
+    pub fn head_dim(&self) -> usize { self.head_dim }
+}
+
+impl Default for Qwen3Config {
+    fn default() -> Self {
+        Self { num_hidden_layers: 2, num_key_value_heads: 2, tensor_parallel_size: 1, head_dim: 64 }
+    }
+}
+
+#[derive(Debug)]
+pub struct Qwen3Model {
+    config: Qwen3Config,
+    _device: Device,
+    _dtype: DType,
+}
+
+impl Qwen3Model {
+    pub fn new(config: Qwen3Config, _rank: usize, device: &Device, dtype: DType) -> CandleResult<Self> {
+        Ok(Self { config, _device: device.clone(), _dtype: dtype })
+    }
+
+    pub fn forward(&self, input_ids: &Tensor, _position_ids: &Tensor) -> CandleResult<Tensor> {
+        let bs = input_ids.dim(0)?;
+        Tensor::zeros((bs, self.config.head_dim), DType::F32, input_ids.device())
+    }
+
+    pub fn config(&self) -> &Qwen3Config { &self.config }
+}

--- a/tiny-vllm-core/src/sampling_params.rs
+++ b/tiny-vllm-core/src/sampling_params.rs
@@ -1,6 +1,27 @@
-//! Equivalent of `nanovllm.sampling_params` in Rust.
+//! Sampling parameters used during token generation.
+//!
+//! This is a trimmed down variant of the Python `SamplingParams` class
+//! providing only the fields required by the Rust implementation.
 
-// Placeholder structure for sampling parameters.
+#[derive(Debug, Clone)]
+pub struct SamplingParams {
+    pub temperature: f32,
+    pub top_p: f32,
+    pub top_k: usize,
+    pub repetition_penalty: f32,
+    pub max_tokens: usize,
+    pub ignore_eos: bool,
+}
 
-#[derive(Debug, Default)]
-pub struct SamplingParams;
+impl Default for SamplingParams {
+    fn default() -> Self {
+        Self {
+            temperature: 1.0,
+            top_p: 1.0,
+            top_k: 0,
+            repetition_penalty: 1.0,
+            max_tokens: 16,
+            ignore_eos: false,
+        }
+    }
+}

--- a/tiny-vllm-core/src/utils/context.rs
+++ b/tiny-vllm-core/src/utils/context.rs
@@ -1,3 +1,68 @@
-//! Context utilities matching `nanovllm.utils.context`.
+//! Execution context utilities.
+//!
+//! The real project maintains an execution context used by the attention
+//! kernels.  For the purpose of these exercises we only implement a very
+//! lightweight placeholder so that the higher level components can compile.
 
-// Placeholder module. Real implementation pending.
+use candle_core::Tensor;
+use anyhow::Result;
+
+#[derive(Debug, Clone, Default)]
+pub struct Context {
+    pub slot_mapping: Option<Tensor>,
+    pub context_lens: Option<Tensor>,
+    pub block_tables: Option<Tensor>,
+    pub cu_seqlens_q: Option<Tensor>,
+    pub cu_seqlens_k: Option<Tensor>,
+}
+
+impl Context {
+    pub fn prefill(
+        cu_seqlens_q: Tensor,
+        cu_seqlens_k: Tensor,
+        _max_seqlen_q: usize,
+        _max_seqlen_k: usize,
+        slot_mapping: Tensor,
+        block_tables: Option<Tensor>,
+    ) -> Self {
+        Self {
+            cu_seqlens_q: Some(cu_seqlens_q),
+            cu_seqlens_k: Some(cu_seqlens_k),
+            slot_mapping: Some(slot_mapping),
+            block_tables,
+            context_lens: None,
+        }
+    }
+
+    pub fn decode(
+        slot_mapping: Tensor,
+        context_lens: Tensor,
+        block_tables: Tensor,
+    ) -> Self {
+        Self {
+            slot_mapping: Some(slot_mapping),
+            context_lens: Some(context_lens),
+            block_tables: Some(block_tables),
+            cu_seqlens_q: None,
+            cu_seqlens_k: None,
+        }
+    }
+}
+
+/// Set the current execution context.
+///
+/// The implementation only stores the context in a thread local for now.
+use std::cell::RefCell;
+thread_local! {
+    static CONTEXT: RefCell<Option<Context>> = const { RefCell::new(None) };
+}
+
+pub fn set_context(ctx: Context) -> Result<()> {
+    CONTEXT.with(|c| *c.borrow_mut() = Some(ctx));
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub fn get_context() -> Option<Context> {
+    CONTEXT.with(|c| c.borrow().clone())
+}


### PR DESCRIPTION
## Summary
- implement lightweight `ModelRunner` in Rust
- add basic `Sequence`, `Sampler`, and `Qwen3Model` stubs
- provide minimal execution context utilities
- extend config with small helper struct
- update sampling parameters
- add candle-core dependency

## Testing
- `cargo test -p tiny-vllm-core -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685ce92b00688331ba2d559a60e82a72